### PR TITLE
Fixed aliens not attacking mobs that are only partially inside resin (even though they're not being eggmorphed)

### DIFF
--- a/common/src/main/java/mods/cybercat/gigeresque/common/block/NestResinWebFullBlock.java
+++ b/common/src/main/java/mods/cybercat/gigeresque/common/block/NestResinWebFullBlock.java
@@ -102,7 +102,10 @@ public class NestResinWebFullBlock extends AbstractNestBlock {
         if (mob instanceof AlienEntity || sourceEntity instanceof AlienEntity) {
             return;
         }
-        if (!mob.hasEffect(GigStatusEffects.EGGMORPHING)) {
+        if (
+            !mob.hasEffect(GigStatusEffects.EGGMORPHING) &&
+                GigEntityUtils.inResinEnoughToBeEggmorphed(mob)
+        ) {
             mob.addEffect(
                 new MobEffectInstance(
                     GigStatusEffects.EGGMORPHING,

--- a/common/src/main/java/mods/cybercat/gigeresque/common/util/GigEntityUtils.java
+++ b/common/src/main/java/mods/cybercat/gigeresque/common/util/GigEntityUtils.java
@@ -302,4 +302,9 @@ public record GigEntityUtils() {
         }
     }
 
+    public static boolean inResinEnoughToBeEggmorphed(@NotNull Entity entity) {
+        var stateAtEntityPos = entity.level().getBlockState(entity.blockPosition());
+        return stateAtEntityPos.is(GigBlocks.NEST_RESIN_WEB_CROSS.get());
+    }
+
 }

--- a/common/src/main/java/mods/cybercat/gigeresque/mixins/common/entity/LivingEntityMixin.java
+++ b/common/src/main/java/mods/cybercat/gigeresque/mixins/common/entity/LivingEntityMixin.java
@@ -21,7 +21,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import mods.cybercat.gigeresque.CommonMod;
 import mods.cybercat.gigeresque.Constants;
-import mods.cybercat.gigeresque.common.block.GigBlocks;
 import mods.cybercat.gigeresque.common.entity.AlienEntity;
 import mods.cybercat.gigeresque.common.entity.helper.GigCommonMethods;
 import mods.cybercat.gigeresque.common.entity.impl.classic.FacehuggerEntity;
@@ -116,11 +115,9 @@ public abstract class LivingEntityMixin extends Entity {
                 }
             }
             if (
-                Constants.hasEggEffect.test(this) && !this.level()
-                    .getBlockState(this.blockPosition())
-                    .is(
-                        GigBlocks.NEST_RESIN_WEB_CROSS.get()
-                    )
+                Constants.hasEggEffect.test(this) &&
+                    !GigEntityUtils.inResinEnoughToBeEggmorphed(this)
+
             ) {
                 this.removeEffect(GigStatusEffects.EGGMORPHING);
             }


### PR DESCRIPTION
There was a disparity between what counts as being inside resin when adding vs removing the eggmorphing effect, which meant mobs touching resin without having their foot position inside it would get the eggmorphing effect constantly added and removed. This prevented aliens and facehuggers from attacking them but never let them actually finish getting eggmorphed. I separated the check into its own method so now they both use the same logic.