### PR TITLE
Make head offset data datapack-driven

### DIFF
--- a/common/src/main/java/mods/cybercat/gigeresque/client/entity/model/FacehuggerModelRenderer.java
+++ b/common/src/main/java/mods/cybercat/gigeresque/client/entity/model/FacehuggerModelRenderer.java
@@ -78,12 +78,10 @@ public class FacehuggerModelRenderer extends AlienModelRenderer<FacehuggerEntity
         poseStack.mulPose(Axis.XP.rotationDegrees(headPitch));
         poseStack.translate(-xPivot, -yPivot + host.getBbHeight(), zPivot);
 
-        var offsetSuppilers = EntityHeadOffsetData.ENTITY_HEAD_OFFSET_DATA_BY_TYPE.get(host.getType());
+        var result = EntityHeadOffsetData.resolve(host.getType(), data, facehuggerEntity);
 
-        if (offsetSuppilers != null) {
-            var yOffset = offsetSuppilers.verticalOffsetSupplier().apply(data, facehuggerEntity);
-            var zOffset = offsetSuppilers.faceOffsetSupplier().apply(data, facehuggerEntity);
-            poseStack.translate(0, yOffset, zOffset);
+        if (result != null) {
+            poseStack.translate(0, result.vertical(), result.face());
         } else {
             poseStack.translate(0, -ySize, zSize);
         }

--- a/common/src/main/java/mods/cybercat/gigeresque/client/entity/render/helper/EntityHeadOffsetData.java
+++ b/common/src/main/java/mods/cybercat/gigeresque/client/entity/render/helper/EntityHeadOffsetData.java
@@ -1,279 +1,113 @@
 package mods.cybercat.gigeresque.client.entity.render.helper;
 
+import com.google.gson.JsonElement;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.BiFunction;
+
+import mods.cybercat.gigeresque.CommonMod;
 
 /**
- * Credit to Boston for this code
+ * Datapack-driven version of the original head-offset table.
+ * <p>
+ * Datapack location: {@code data/<namespace>/gigeresque_head_offsets/<entity>.json}
+ * <p>
+ * Each JSON file looks like:
+ *
+ * <pre>{@code
+ * {
+ *   "entity": "minecraft:cow",
+ *   "vertical_offset": "-size_y",
+ *   "face_offset": "size_z + (size_z / 2) + parasite_height"
+ * }
+ * }</pre>
+ * <p>
+ * See {@link OffsetExpression} for the supported expression grammar.
+ * <p>
+ * Credit to Boston for the original head-offset table code.
  */
 public record EntityHeadOffsetData(
-    BiFunction<EntityHeadData, Entity, Double> verticalOffsetSupplier,
-    BiFunction<EntityHeadData, Entity, Double> faceOffsetSupplier
-
+    OffsetExpression verticalOffset,
+    OffsetExpression faceOffset
 ) {
 
-    private static final EntityHeadOffsetData COW = new EntityHeadOffsetData(
-        EntityHeadOffsetData::cowVerticalOffset,
-        EntityHeadOffsetData::cowFaceOffset
+    public static final Codec<EntityHeadOffsetData> CODEC = RecordCodecBuilder.create(
+        instance -> instance.group(
+            OffsetExpression.CODEC.fieldOf("vertical_offset").forGetter(EntityHeadOffsetData::verticalOffset),
+            OffsetExpression.CODEC.fieldOf("face_offset").forGetter(EntityHeadOffsetData::faceOffset)
+        ).apply(instance, EntityHeadOffsetData::new)
     );
 
-    private static final EntityHeadOffsetData LLAMA = new EntityHeadOffsetData(
-        EntityHeadOffsetData::llamaVerticalOffset,
-        EntityHeadOffsetData::llamaFaceOffset
-    );
+    public static volatile Map<EntityType<?>, EntityHeadOffsetData> ENTITY_HEAD_OFFSET_DATA_BY_TYPE = Map.of();
 
-    private static final EntityHeadOffsetData VILLAGER = new EntityHeadOffsetData(
-        EntityHeadOffsetData::villagerVerticalOffset,
-        EntityHeadOffsetData::villagerFaceOffset
-    );
-
-    public static final Map<EntityType<?>, EntityHeadOffsetData> ENTITY_HEAD_OFFSET_DATA_BY_TYPE = new HashMap<>(
-        Map.ofEntries(
-            Map.entry(
-                EntityType.CAMEL,
-                new EntityHeadOffsetData(EntityHeadOffsetData::camelVerticalOffset, EntityHeadOffsetData::camelFaceOffset)
-            ),
-            Map.entry(EntityType.COW, COW),
-            Map.entry(
-                EntityType.DONKEY,
-                new EntityHeadOffsetData(EntityHeadOffsetData::donkeyVerticalOffset, EntityHeadOffsetData::donkeyFaceOffset)
-            ),
-            Map.entry(
-                EntityType.DOLPHIN,
-                new EntityHeadOffsetData(EntityHeadOffsetData::dolphinVerticalOffset, EntityHeadOffsetData::dolphinFaceOffset)
-            ),
-            Map.entry(EntityType.EVOKER, VILLAGER),
-            Map.entry(
-                EntityType.FOX,
-                new EntityHeadOffsetData(EntityHeadOffsetData::foxVerticalOffset, EntityHeadOffsetData::foxFaceOffset)
-            ),
-            Map.entry(
-                EntityType.GOAT,
-                new EntityHeadOffsetData(EntityHeadOffsetData::goatVerticalOffset, EntityHeadOffsetData::goatFaceOffset)
-            ),
-            Map.entry(
-                EntityType.HOGLIN,
-                new EntityHeadOffsetData(EntityHeadOffsetData::hoglinVerticalOffset, EntityHeadOffsetData::hoglinFaceOffset)
-            ),
-            Map.entry(
-                EntityType.HORSE,
-                new EntityHeadOffsetData(EntityHeadOffsetData::horseVerticalOffset, EntityHeadOffsetData::horseFaceOffset)
-            ),
-            Map.entry(EntityType.ILLUSIONER, VILLAGER),
-            Map.entry(EntityType.LLAMA, LLAMA),
-            Map.entry(EntityType.MOOSHROOM, COW),
-            Map.entry(
-                EntityType.MULE,
-                new EntityHeadOffsetData(EntityHeadOffsetData::muleVerticalOffset, EntityHeadOffsetData::muleFaceOffset)
-            ),
-            Map.entry(
-                EntityType.PANDA,
-                new EntityHeadOffsetData(EntityHeadOffsetData::pandaVerticalOffset, EntityHeadOffsetData::pandaFaceOffset)
-            ),
-            Map.entry(
-                EntityType.PIG,
-                new EntityHeadOffsetData(EntityHeadOffsetData::pigVerticalOffset, EntityHeadOffsetData::pigFaceOffset)
-            ),
-            Map.entry(EntityType.PIGLIN, VILLAGER),
-            Map.entry(EntityType.PIGLIN_BRUTE, VILLAGER),
-            Map.entry(EntityType.PILLAGER, VILLAGER),
-            Map.entry(
-                EntityType.PLAYER,
-                new EntityHeadOffsetData(EntityHeadOffsetData::playerVerticalOffset, EntityHeadOffsetData::playerFaceOffset)
-            ),
-            Map.entry(
-                EntityType.POLAR_BEAR,
-                new EntityHeadOffsetData(EntityHeadOffsetData::polarBearVerticalOffset, EntityHeadOffsetData::polarBearFaceOffset)
-            ),
-            Map.entry(
-                EntityType.RAVAGER,
-                new EntityHeadOffsetData(EntityHeadOffsetData::ravagerVerticalOffset, EntityHeadOffsetData::ravagerFaceOffset)
-            ),
-            Map.entry(
-                EntityType.SHEEP,
-                new EntityHeadOffsetData(EntityHeadOffsetData::sheepVerticalOffset, EntityHeadOffsetData::sheepFaceOffset)
-            ),
-            Map.entry(
-                EntityType.SNIFFER,
-                new EntityHeadOffsetData(EntityHeadOffsetData::snifferVerticalOffset, EntityHeadOffsetData::snifferFaceOffset)
-            ),
-            Map.entry(EntityType.TRADER_LLAMA, LLAMA),
-            Map.entry(EntityType.VILLAGER, VILLAGER),
-            Map.entry(EntityType.WANDERING_TRADER, VILLAGER),
-            Map.entry(EntityType.VINDICATOR, VILLAGER),
-            Map.entry(
-                EntityType.WITCH,
-                new EntityHeadOffsetData(EntityHeadOffsetData::witchVerticalOffset, EntityHeadOffsetData::villagerFaceOffset)
-            ),
-            Map.entry(
-                EntityType.WOLF,
-                new EntityHeadOffsetData(EntityHeadOffsetData::wolfVerticalOffset, EntityHeadOffsetData::wolfFaceOffset)
-            ),
-            Map.entry(
-                EntityType.ZOGLIN,
-                new EntityHeadOffsetData(EntityHeadOffsetData::hoglinVerticalOffset, EntityHeadOffsetData::hoglinFaceOffset)
-            ),
-            Map.entry(EntityType.ZOMBIE_VILLAGER, VILLAGER)
-        )
-    );
-
-    private static double camelVerticalOffset(EntityHeadData data, Entity parasite) {
-        return data.size().y / 1.5;
+    public static OffsetResult resolve(EntityType<?> hostType, EntityHeadData head, Entity parasite) {
+        EntityHeadOffsetData data = ENTITY_HEAD_OFFSET_DATA_BY_TYPE.get(hostType);
+        if (data == null) {
+            return null;
+        }
+        OffsetExpression.OffsetContext ctx = new OffsetExpression.OffsetContext(
+            head.size().x,
+            head.size().y,
+            head.size().z,
+            head.pivot().x,
+            head.pivot().y,
+            head.pivot().z,
+            parasite.getBbHeight(),
+            parasite.getBbWidth()
+        );
+        return new OffsetResult(data.verticalOffset.evaluate(ctx), data.faceOffset.evaluate(ctx));
     }
 
-    private static double camelFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z + parasite.getBbHeight();
-    }
+    public record OffsetResult(
+        double vertical,
+        double face
+    ) {}
 
-    private static double cowVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y;
-    }
+    public static class ReloadListener extends SimpleJsonResourceReloadListener {
 
-    private static double cowFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z + (data.size().z / 2) + parasite.getBbHeight();
-    }
+        public ReloadListener() {
+            super(new com.google.gson.GsonBuilder().create(), "gigeresque_head_offsets");
+        }
 
-    private static double donkeyVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y / 4;
-    }
+        @Override
+        protected void apply(Map<ResourceLocation, JsonElement> jsons, @NotNull ResourceManager rm, @NotNull ProfilerFiller profiler) {
+            Map<EntityType<?>, EntityHeadOffsetData> map = new HashMap<>();
+            for (var entry : jsons.entrySet()) {
+                var file = entry.getKey();
+                try {
+                    var obj = GsonHelper.convertToJsonObject(entry.getValue(), "head_offset");
+                    ResourceLocation entityId;
+                    if (obj.has("entity")) {
+                        entityId = ResourceLocation.parse(GsonHelper.getAsString(obj, "entity"));
+                    } else {
+                        entityId = ResourceLocation.fromNamespaceAndPath("minecraft", file.getPath());
+                    }
 
-    private static double donkeyFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z * 2 + data.size().z / 1.4;
-    }
+                    var type = BuiltInRegistries.ENTITY_TYPE.getOptional(entityId)
+                        .orElseThrow(() -> new IllegalArgumentException("Unknown entity type: " + entityId));
 
-    private static double foxVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 1.3);
-    }
+                    var data = CODEC.parse(JsonOps.INSTANCE, entry.getValue())
+                        .getOrThrow(IllegalArgumentException::new);
 
-    private static double foxFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z * 1.7 + parasite.getBbHeight();
-    }
-
-    private static double goatVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 4);
-    }
-
-    private static double goatFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z + (data.size().z / 3) + parasite.getBbHeight() / 4;
-    }
-
-    private static double hoglinVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - data.size().y * 2.3;
-    }
-
-    private static double hoglinFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z + (data.size().z / 10) + parasite.getBbHeight();
-    }
-
-    private static double horseVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y / 4;
-    }
-
-    private static double horseFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z * 3 + data.size().z / 2;
-    }
-
-    private static double llamaVerticalOffset(EntityHeadData data, Entity parasite) {
-        return data.size().y / 2.5;
-    }
-
-    private static double llamaFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z + (data.size().z / 1.5) + parasite.getBbHeight();
-    }
-
-    private static double muleVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y / 4;
-    }
-
-    private static double muleFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z * 2 + data.size().z / 1.2;
-    }
-
-    private static double pigVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y;
-    }
-
-    private static double pigFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z + (data.size().z / 2) + parasite.getBbHeight() / 2;
-    }
-
-    private static double pandaVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 2);
-    }
-
-    private static double pandaFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z * 2 + parasite.getBbHeight();
-    }
-
-    private static double playerVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 4);
-    }
-
-    private static double playerFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z - (data.size().z / 2);
-    }
-
-    private static double polarBearVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 1.15);
-    }
-
-    private static double polarBearFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z * 3 + parasite.getBbHeight();
-    }
-
-    private static double ravagerVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - data.size().y / 4;
-    }
-
-    private static double ravagerFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z + (data.size().z / 1.75) + parasite.getBbHeight();
-    }
-
-    private static double sheepVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 4);
-    }
-
-    private static double sheepFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z + (data.size().z / 3) + parasite.getBbHeight() / 2;
-    }
-
-    private static double snifferVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 2);
-    }
-
-    private static double snifferFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z * 3 + (data.size().z / 2);
-    }
-
-    private static double villagerVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 4);
-    }
-
-    private static double villagerFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z - (data.size().z / 1) + 0.3;
-    }
-
-    private static double witchVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 1.5);
-    }
-
-    private static double wolfVerticalOffset(EntityHeadData data, Entity parasite) {
-        return -data.size().y - (data.size().y / 1.9);
-    }
-
-    private static double wolfFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z * 1.9 + parasite.getBbHeight();
-    }
-
-    private static double dolphinVerticalOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z - data.size().z - 0.7;
-    }
-
-    private static double dolphinFaceOffset(EntityHeadData data, Entity parasite) {
-        return data.size().z * 2 + data.size().z + 0.1;
+                    map.put(type, data);
+                } catch (Exception e) {
+                    CommonMod.LOGGER.error("Failed to load head offset {}: {}", file, e.getMessage());
+                }
+            }
+            ENTITY_HEAD_OFFSET_DATA_BY_TYPE = Map.copyOf(map);
+            CommonMod.LOGGER.info("Loaded {} entity head offset entries", map.size());
+        }
     }
 }

--- a/common/src/main/java/mods/cybercat/gigeresque/client/entity/render/helper/OffsetExpression.java
+++ b/common/src/main/java/mods/cybercat/gigeresque/client/entity/render/helper/OffsetExpression.java
@@ -1,0 +1,232 @@
+package mods.cybercat.gigeresque.client.entity.render.helper;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * A tiny arithmetic expression evaluator used to express head-offset formulas in JSON.
+ * <p>
+ * Supported tokens:
+ * <ul>
+ * <li>Numeric literals: {@code 1}, {@code 2.5}, {@code 0.7}</li>
+ * <li>Variables: {@code size_x}, {@code size_y}, {@code size_z}, {@code pivot_x}, {@code pivot_y}, {@code pivot_z},
+ * {@code parasite_height}, {@code parasite_width}</li>
+ * <li>Operators: {@code + - * /} with conventional precedence</li>
+ * <li>Parentheses: {@code (} {@code )}</li>
+ * <li>Unary minus: {@code -size_y}</li>
+ * </ul>
+ * <p>
+ * Examples (these reproduce the original hard-coded formulas):
+ *
+ * <pre>
+ *   cow vertical_offset:  -size_y
+ *   cow face_offset:      size_z + (size_z / 2) + parasite_height
+ *   horse face_offset:    size_z * 3 + size_z / 2
+ *   wolf vertical_offset: -size_y - (size_y / 1.9)
+ * </pre>
+ */
+public final class OffsetExpression {
+
+    public static final Codec<OffsetExpression> CODEC = Codec.STRING.comapFlatMap(
+        s -> {
+            try {
+                return DataResult.success(parse(s));
+            } catch (IllegalArgumentException e) {
+                return DataResult.error(() -> "Invalid offset expression '" + s + "': " + e.getMessage());
+            }
+        },
+        OffsetExpression::source
+    );
+
+    private final String source;
+
+    private final List<Token> rpn;
+
+    private OffsetExpression(String source, List<Token> rpn) {
+        this.source = source;
+        this.rpn = rpn;
+    }
+
+    public String source() {
+        return source;
+    }
+
+    public double evaluate(OffsetContext ctx) {
+        Deque<Double> stack = new ArrayDeque<>();
+        for (var t : rpn) {
+            switch (t.kind) {
+                case NUMBER -> stack.push(t.number);
+                case VARIABLE -> stack.push(resolve(t.text, ctx));
+                case OPERATOR -> {
+                    double b = stack.pop();
+                    double a = stack.isEmpty() ? 0.0 : stack.pop(); // unary minus support
+                    stack.push(applyOp(t.text.charAt(0), a, b));
+                }
+                case UNARY_MINUS -> {
+                    double v = stack.pop();
+                    stack.push(-v);
+                }
+            }
+        }
+        return stack.isEmpty() ? 0.0 : stack.pop();
+    }
+
+    private static double resolve(String name, OffsetContext ctx) {
+        return switch (name) {
+            case "size_x" -> ctx.sizeX();
+            case "size_y" -> ctx.sizeY();
+            case "size_z" -> ctx.sizeZ();
+            case "pivot_x" -> ctx.pivotX();
+            case "pivot_y" -> ctx.pivotY();
+            case "pivot_z" -> ctx.pivotZ();
+            case "parasite_height" -> ctx.parasiteHeight();
+            case "parasite_width" -> ctx.parasiteWidth();
+            default -> throw new IllegalArgumentException("Unknown variable: " + name);
+        };
+    }
+
+    private static double applyOp(char op, double a, double b) {
+        return switch (op) {
+            case '+' -> a + b;
+            case '-' -> a - b;
+            case '*' -> a * b;
+            case '/' -> a / b;
+            default -> throw new IllegalArgumentException("Unknown operator: " + op);
+        };
+    }
+
+    public static OffsetExpression parse(String expr) {
+        var tokens = tokenize(expr);
+        List<Token> output = new ArrayList<>();
+        Deque<Token> ops = new ArrayDeque<>();
+
+        Token prev = null;
+        for (var t : tokens) {
+            switch (t.kind) {
+                case NUMBER, VARIABLE -> output.add(t);
+                case OPERATOR -> {
+                    if (t.text.equals("-") && (prev == null || prev.kind == TokenKind.OPERATOR || prev.kind == TokenKind.LPAREN)) {
+                        ops.push(new Token(TokenKind.UNARY_MINUS, "-", 0));
+                    } else {
+                        while (
+                            !ops.isEmpty()
+                                && (ops.peek().kind == TokenKind.OPERATOR || ops.peek().kind == TokenKind.UNARY_MINUS)
+                                && precedence(ops.peek()) >= precedence(t)
+                        ) {
+                            output.add(ops.pop());
+                        }
+                        ops.push(t);
+                    }
+                }
+                case LPAREN -> ops.push(t);
+                case RPAREN -> {
+                    while (!ops.isEmpty() && ops.peek().kind != TokenKind.LPAREN) {
+                        output.add(ops.pop());
+                    }
+                    if (ops.isEmpty()) {
+                        throw new IllegalArgumentException("Mismatched parentheses");
+                    }
+                    ops.pop();
+                }
+                default -> throw new IllegalArgumentException("Unexpected token: " + t.text);
+            }
+            prev = t;
+        }
+        while (!ops.isEmpty()) {
+            Token t = ops.pop();
+            if (t.kind == TokenKind.LPAREN) {
+                throw new IllegalArgumentException("Mismatched parentheses");
+            }
+            output.add(t);
+        }
+
+        return new OffsetExpression(expr, output);
+    }
+
+    private static int precedence(Token t) {
+        if (t.kind == TokenKind.UNARY_MINUS)
+            return 3;
+        return switch (t.text) {
+            case "+", "-" -> 1;
+            case "*", "/" -> 2;
+            default -> 0;
+        };
+    }
+
+    private static List<Token> tokenize(String expr) {
+        List<Token> tokens = new ArrayList<>();
+        var i = 0;
+        var n = expr.length();
+        while (i < n) {
+            var c = expr.charAt(i);
+            if (Character.isWhitespace(c)) {
+                i++;
+            } else if (Character.isDigit(c) || c == '.') {
+                var start = i;
+                while (i < n && (Character.isDigit(expr.charAt(i)) || expr.charAt(i) == '.')) {
+                    i++;
+                }
+                tokens.add(
+                    new Token(
+                        TokenKind.NUMBER,
+                        expr.substring(start, i),
+                        Double.parseDouble(expr.substring(start, i))
+                    )
+                );
+            } else if (Character.isLetter(c) || c == '_') {
+                var start = i;
+                while (i < n && (Character.isLetterOrDigit(expr.charAt(i)) || expr.charAt(i) == '_')) {
+                    i++;
+                }
+                tokens.add(new Token(TokenKind.VARIABLE, expr.substring(start, i), 0));
+            } else if (c == '+' || c == '-' || c == '*' || c == '/') {
+                tokens.add(new Token(TokenKind.OPERATOR, String.valueOf(c), 0));
+                i++;
+            } else if (c == '(') {
+                tokens.add(new Token(TokenKind.LPAREN, "(", 0));
+                i++;
+            } else if (c == ')') {
+                tokens.add(new Token(TokenKind.RPAREN, ")", 0));
+                i++;
+            } else {
+                throw new IllegalArgumentException("Unexpected character '" + c + "' at index " + i);
+            }
+        }
+        return tokens;
+    }
+
+    private enum TokenKind {
+        NUMBER,
+        VARIABLE,
+        OPERATOR,
+        LPAREN,
+        RPAREN,
+        UNARY_MINUS
+    }
+
+    private record Token(
+        TokenKind kind,
+        String text,
+        double number
+    ) {}
+
+    /**
+     * Snapshot of the values an offset expression can reference. Built per-frame from the host's head data and the
+     * parasite entity.
+     */
+    public record OffsetContext(
+        double sizeX,
+        double sizeY,
+        double sizeZ,
+        double pivotX,
+        double pivotY,
+        double pivotZ,
+        double parasiteHeight,
+        double parasiteWidth
+    ) {}
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/camel.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/camel.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:camel",
+  "vertical_offset": "size_y / 1.5",
+  "face_offset": "size_z + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/cow.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/cow.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:cow",
+  "vertical_offset": "-size_y",
+  "face_offset": "size_z + (size_z / 2) + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/dolphin.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/dolphin.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:dolphin",
+  "vertical_offset": "size_z - size_z - 0.7",
+  "face_offset": "size_z * 2 + size_z + 0.1"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/donkey.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/donkey.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:donkey",
+  "vertical_offset": "-size_y / 4",
+  "face_offset": "size_z * 2 + size_z / 1.4"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/evoker.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/evoker.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:evoker",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/fox.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/fox.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:fox",
+  "vertical_offset": "-size_y - (size_y / 1.3)",
+  "face_offset": "size_z * 1.7 + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/goat.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/goat.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:goat",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z + (size_z / 3) + parasite_height / 4"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/hoglin.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/hoglin.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:hoglin",
+  "vertical_offset": "-size_y - size_y * 2.3",
+  "face_offset": "size_z + (size_z / 10) + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/horse.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/horse.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:horse",
+  "vertical_offset": "-size_y / 4",
+  "face_offset": "size_z * 3 + size_z / 2"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/illusioner.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/illusioner.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:illusioner",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/llama.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/llama.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:llama",
+  "vertical_offset": "size_y / 2.5",
+  "face_offset": "size_z + (size_z / 1.5) + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/mooshroom.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/mooshroom.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:mooshroom",
+  "vertical_offset": "-size_y",
+  "face_offset": "size_z + (size_z / 2) + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/mule.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/mule.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:mule",
+  "vertical_offset": "-size_y / 4",
+  "face_offset": "size_z * 2 + size_z / 1.2"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/panda.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/panda.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:panda",
+  "vertical_offset": "-size_y - (size_y / 2)",
+  "face_offset": "size_z * 2 + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/pig.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/pig.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:pig",
+  "vertical_offset": "-size_y",
+  "face_offset": "size_z + (size_z / 2) + parasite_height / 2"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/piglin.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/piglin.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:piglin",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/piglin_brute.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/piglin_brute.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:piglin_brute",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/pillager.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/pillager.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:pillager",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/player.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/player.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:player",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 2)"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/polar_bear.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/polar_bear.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:polar_bear",
+  "vertical_offset": "-size_y - (size_y / 1.15)",
+  "face_offset": "size_z * 3 + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/ravager.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/ravager.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:ravager",
+  "vertical_offset": "-size_y - size_y / 4",
+  "face_offset": "size_z + (size_z / 1.75) + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/sheep.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/sheep.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:sheep",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z + (size_z / 3) + parasite_height / 2"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/sniffer.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/sniffer.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:sniffer",
+  "vertical_offset": "-size_y - (size_y / 2)",
+  "face_offset": "size_z * 3 + (size_z / 2)"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/trader_llama.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/trader_llama.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:trader_llama",
+  "vertical_offset": "size_y / 2.5",
+  "face_offset": "size_z + (size_z / 1.5) + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/villager.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/villager.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:villager",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/vindicator.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/vindicator.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:vindicator",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/wandering_trader.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/wandering_trader.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:wandering_trader",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/witch.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/witch.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:witch",
+  "vertical_offset": "-size_y - (size_y / 1.5)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/wolf.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/wolf.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:wolf",
+  "vertical_offset": "-size_y - (size_y / 1.9)",
+  "face_offset": "size_z * 1.9 + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/zoglin.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/zoglin.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:zoglin",
+  "vertical_offset": "-size_y - size_y * 2.3",
+  "face_offset": "size_z + (size_z / 10) + parasite_height"
+}

--- a/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/zombie_villager.json
+++ b/common/src/main/resources/data/gigeresque/gigeresque_head_offsets/zombie_villager.json
@@ -1,0 +1,5 @@
+{
+  "entity": "minecraft:zombie_villager",
+  "vertical_offset": "-size_y - (size_y / 4)",
+  "face_offset": "size_z - (size_z / 1) + 0.3"
+}

--- a/fabric/src/main/java/mods/cybercat/gigeresque/FabricMod.java
+++ b/fabric/src/main/java/mods/cybercat/gigeresque/FabricMod.java
@@ -5,10 +5,13 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
+import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.packs.PackType;
 import net.minecraft.world.level.GameRules;
 
+import mods.cybercat.gigeresque.client.FabricHeadOffsetReloadListener;
 import mods.cybercat.gigeresque.common.entity.GigEntities;
 import mods.cybercat.gigeresque.common.entity.impl.aqua.AquaticAlienEntity;
 import mods.cybercat.gigeresque.common.entity.impl.classic.AlienEggEntity;
@@ -43,6 +46,8 @@ public final class FabricMod implements ModInitializer {
     @Override
     public void onInitialize() {
         CommonMod.initRegistries();
+        ResourceManagerHelper.get(PackType.SERVER_DATA)
+            .registerReloadListener(new FabricHeadOffsetReloadListener());
         FlammableBlockRegistry.getDefaultInstance().add(GigTags.NEST_BLOCKS, 5, 5);
         MobSpawn.initialize();
         FabricDefaultAttributeRegistry.register(GigEntities.ALIEN.get(), ClassicAlienEntity.createAttributes());

--- a/fabric/src/main/java/mods/cybercat/gigeresque/client/FabricHeadOffsetReloadListener.java
+++ b/fabric/src/main/java/mods/cybercat/gigeresque/client/FabricHeadOffsetReloadListener.java
@@ -1,0 +1,15 @@
+package mods.cybercat.gigeresque.client;
+
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.minecraft.resources.ResourceLocation;
+
+import mods.cybercat.gigeresque.Constants;
+import mods.cybercat.gigeresque.client.entity.render.helper.EntityHeadOffsetData;
+
+public class FabricHeadOffsetReloadListener extends EntityHeadOffsetData.ReloadListener implements IdentifiableResourceReloadListener {
+
+    @Override
+    public ResourceLocation getFabricId() {
+        return Constants.modResource("gigeresque_head_offsets");
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ fabric_loader_version                = 0.17.3
 
 # Libs
 modmenu_version                      = 11.0.3
-azurelib_version                     = 3.1.1
+azurelib_version                     = 3.1.8
 
 # Mod options
 group                                = mods.cybercat.gigeresque

--- a/neoforge/src/main/java/mods/cybercat/gigeresque/NeoForgeClientMod.java
+++ b/neoforge/src/main/java/mods/cybercat/gigeresque/NeoForgeClientMod.java
@@ -57,7 +57,7 @@ import mods.cybercat.gigeresque.common.item.GigItems;
 import mods.cybercat.gigeresque.common.predicates.*;
 import mods.cybercat.gigeresque.hacky.BlackFluidClientExtensions;
 
-@EventBusSubscriber(modid = CommonMod.MOD_ID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+@EventBusSubscriber(modid = CommonMod.MOD_ID, value = Dist.CLIENT)
 public class NeoForgeClientMod {
 
     @SubscribeEvent

--- a/neoforge/src/main/java/mods/cybercat/gigeresque/NeoForgeMod.java
+++ b/neoforge/src/main/java/mods/cybercat/gigeresque/NeoForgeMod.java
@@ -42,6 +42,7 @@ import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.SoundActions;
 import net.neoforged.neoforge.common.world.BiomeModifier;
 import net.neoforged.neoforge.common.world.ModifiableBiomeInfo;
+import net.neoforged.neoforge.event.AddReloadListenerEvent;
 import net.neoforged.neoforge.event.entity.EntityAttributeCreationEvent;
 import net.neoforged.neoforge.event.entity.RegisterSpawnPlacementsEvent;
 import net.neoforged.neoforge.event.tick.LevelTickEvent;
@@ -52,6 +53,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
 
+import mods.cybercat.gigeresque.client.entity.render.helper.EntityHeadOffsetData;
 import mods.cybercat.gigeresque.common.entity.GigEntities;
 import mods.cybercat.gigeresque.common.entity.impl.aqua.AquaticAlienEntity;
 import mods.cybercat.gigeresque.common.entity.impl.classic.AlienEggEntity;
@@ -182,6 +184,7 @@ public final class NeoForgeMod {
         NeoForgeMod.creativeModeTabDeferredRegister.register(modEventBus);
         NeoForgeMod.statusEffectDeferredRegister.register(modEventBus);
         NeoForgeMod.fluidDeferredRegister.register(modEventBus);
+        NeoForge.EVENT_BUS.addListener((AddReloadListenerEvent event) -> event.addListener(new EntityHeadOffsetData.ReloadListener()));
         modEventBus.addListener(this::createEntityAttributes);
         modEventBus.addListener(this::onRegisterEvent);
         ModEntitySpawn.SERIALIZER.register(modEventBus);


### PR DESCRIPTION
Replaces the hardcoded EntityHeadOffsetData table with a datapack-driven system, allowing pack authors and modders to define facehugger head-attachment offsets easily without depending on the mod.